### PR TITLE
python3: fixing exception syntax

### DIFF
--- a/tondeuse.py
+++ b/tondeuse.py
@@ -17,7 +17,7 @@ try:
     opts, args = getopt.getopt(sys.argv[1:], 's:f:ih',
                                ['slow=', 'fast=', 'nocolor', 'miss=','nowait',
                                 'nointerrupt'])
-except (getopt.GetoptError, err):
+except getopt.GetoptError as err:
     # print help information and exit:
     print(str(err)) # will print something like "option -a not recognized"
     usage()


### PR DESCRIPTION
Correct syntax for a single exception bound to a name is with `as`

Test Plan:
```python3 tondeuse.py --toto```

Must display the valid `--help` message